### PR TITLE
Preparar Dockerfile e settings.py para deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED 1
+ENV PRODUCTION 1
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libpq-dev \
+    default-libmysqlclient-dev \
+    pkg-config \
+    tree \
+    && rm -rf /var/lib/apt/lists/*
+
+
+COPY requirements.txt /app/
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
+
+COPY ./ /app/
+
+WORKDIR /app/tb_project
+
+RUN python manage.py collectstatic --noinput
+
+RUN tree .. -I __pycache__ -I venv
+
+EXPOSE 8000
+
+CMD ["gunicorn", "tb_project.wsgi:application", "--bind", "0.0.0.0:8000", "--workers", "2"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpq-dev \
     default-libmysqlclient-dev \
     pkg-config \
-    tree \
     && rm -rf /var/lib/apt/lists/*
 
 
@@ -24,8 +23,6 @@ COPY ./ /app/
 WORKDIR /app/tb_project
 
 RUN python manage.py collectstatic --noinput
-
-RUN tree .. -I __pycache__ -I venv
 
 EXPOSE 8000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN pip install -r requirements.txt
 COPY ./ /app/
 
 WORKDIR /app/tb_project
+ENV PRODUCTION=true
 
 RUN python manage.py collectstatic --noinput
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+asgiref==3.9.1
+Django==5.2.6
+gunicorn==23.0.0
+mysql-connector-python==9.4.0
+mysqlclient==2.2.7
+packaging==25.0
+sqlparse==0.5.3
+whitenoise==6.9.0

--- a/tb_project/tb_project/settings.py
+++ b/tb_project/tb_project/settings.py
@@ -23,11 +23,13 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = 'django-insecure-0qn($(b(y%oosanyz%=s*fv@v@_kq8i7pkf7iu()$rrk#+hv1='
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+if "PRODUCTION" in os.environ:
+    DEBUG = False
+else:
+    DEBUG = True
 
-ALLOWED_HOSTS = []
-
+# TODO: em producao de verdade, colocariamos os hosts a serem usados aq
+ALLOWED_HOSTS = ['*']
 
 # Application definition
 
@@ -43,6 +45,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -50,6 +53,9 @@ MIDDLEWARE = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]
+
+# para servir os arquivos estáticos com o gunicorn
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 ROOT_URLCONF = 'tb_project.urls'
 
@@ -121,15 +127,14 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 
-STATIC_ROOT = BASE_DIR / 'productionfiles'
+STATIC_ROOT = BASE_DIR / 'static'
 
-STATIC_URL = 'static/'
+STATIC_URL = '/static/'
 
 #Add this in your settings.py file:
 STATICFILES_DIRS = [
     BASE_DIR / 'mystaticfiles'
 ]
-
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field


### PR DESCRIPTION
Adicionei uma Dockerfile e modifiquei as configurações do servidor django para realizar deploy em plataformas como railway e render.
Detalhe: alguns arquivos de mídia estáticos (como fotos) estão em /media ao invés de em /static. Como, por padrão, o django permite apenas um diretório para arquivos estaticos em ambiente de produção, é necessário mover tudo que está em /media para /static, e trocar os URLs no HTML.